### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     python-dev \
     texlive-fonts-extra \
     texlive-fonts-recommended \
-    texlive-generic-recommended \
+    texlive-plain-generic \
     texlive-latex-base \
     texlive-latex-extra \
     texlive-xetex \


### PR DESCRIPTION
the package 'texlive-generic-recommended' is no longer available and replaced with 'texlive-plain-generic'